### PR TITLE
Create basic style guide for special profile, closes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 <img src="/images/banner.jpg" alt="matthewctechnology">
-<a href="https:/matthewctechnology/matthewctechnology/wiki">Home</a> | 
-<a href="https:/matthewctechnology/matthewctechnology/wiki/matthewctechnology-Profile-Style-Guide">Wiki Markdown Style Guide</a> | 
+<a href="https:/matthewctechnology/matthewctechnology/wiki">Wiki Home</a> | 
+<a href="https:/matthewctechnology/matthewctechnology/wiki/matthewctechnology-Profile-Style-Guide">Wiki Style Guide</a> | 
 <a href="https:/matthewctechnology/matthewctechnology/wiki">matthewctechnology wiki - New!</a>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 <img src="/images/banner.jpg" alt="matthewctechnology">
-<a href="https:/matthewctechnology/matthewctechnology/wiki">Home</a> | <a href="https:/matthewctechnology/matthewctechnology/wiki">matthewctechnology wiki - New!</a>
+<a href="https:/matthewctechnology/matthewctechnology/wiki">Home</a> | 
+<a href="https:/matthewctechnology/matthewctechnology/wiki/matthewctechnology-Profile-Style-Guide">Wiki Markdown Style Guide</a> | 
+<a href="https:/matthewctechnology/matthewctechnology/wiki">matthewctechnology wiki - New!</a>


### PR DESCRIPTION
Create a style guide for the special profile by providing simple wiki styles that match the GitHub style.

This is simple using the provided GitHub markdown in the wiki.  There is a help with formatting link at the bottom of every wiki page in the web editor.  And there is a set of helper buttons at the top.

To do items from #17 
- [x] match styles of GitHub profile so it fits nicely
- [x] heading and paragraph usage in wiki, keep it simple
- [x] ~color palette~ can't do colors and footnotes in wiki

Page is [matthewctechnology wiki style guide](../../matthewctechnology/wiki/matthewctechnology-profile-style-guide)  